### PR TITLE
Sc 98275/use qtwebengine not qtwebkit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/bin/bash .devcontainer/setup.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,7 +5,7 @@ sudo apt-get -y update
 # Enable tab autocomplete in terminal
 sudo apt install bash-completion
 
-# Install tools required to build
+# Install tools/libraries required to build
 sudo apt-get install -y \
     gyp \
     libegl1-mesa-dev \
@@ -18,9 +18,29 @@ sudo apt-get install -y \
     libpng-dev \
     libxslt1-dev \
 
+# Install Qt
+sudo apt-get install -y \
+    qtbase5-dev \
+    qtdeclarative5-dev \
+    qtmultimedia5-dev \
+    qtpositioning5-dev \
+    libqt5sensors5-dev \
+    libqt5webchannel5 \
+    qt5-qmake \
+
 # Alias python3 to python so the build script can find it
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
-# Download our prebuilt version of Qt
-curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar -xJC /opt
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+# Download our prebuilt version of QtWebkit
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
+
+# Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
+sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,6 +8,7 @@ sudo apt install bash-completion
 # Install tools/libraries required to build
 sudo apt-get install -y \
     gyp \
+    libdbus-1-dev \
     libegl1-mesa-dev \
     libglib2.0-dev \
     libgstreamer1.0-dev \
@@ -20,38 +21,12 @@ sudo apt-get install -y \
     libxslt1-dev \
     libwebpdemux2 \
     libwoff1 \
-
-# Install Qt
-sudo apt-get install -y \
-    libqt6core5compat6-dev \
-    libqt6sensors6-dev \
-    qt6-base-dev \
-    qt6-declarative-dev \
-    qt6-multimedia-dev \
-    qt6-positioning-dev \
-
-# Qt executables go through "qtchooser" by default. It is broken. Just replace the "qtchooser" versions with a link to the executable we actually want to run
-# If you see an error of "thng: could not find a Qt installation of ''" then that means that `thng` is another executable that needs the following treatment.
-sudo rm /usr/bin/qmake
-sudo ln -s /usr/lib/qt6/bin/qmake /usr/bin/qmake
-sudo rm /usr/bin/moc
-sudo ln -s /usr/lib/qt6/libexec/moc /usr/bin/moc
-sudo rm /usr/bin/uic
-sudo ln -s /usr/lib/qt6/libexec/uic /usr/bin/uic
+    libxkbcommon-dev \
 
 # Alias python3 to python so the build script can find it
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
+# Download our prebuilt version of Qt
+curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
 # Download our prebuilt version of QtWebkit
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
-
-# Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
-sudo mv /usr/include/x86_64-linux-gnu/qt6/include/* /usr/include/x86_64-linux-gnu/qt6/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt6/include/
-
-sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/cmake/
-sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/pkgconfig/
-sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/* /usr/lib/x86_64-linux-gnu/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -27,6 +27,4 @@ sudo apt-get install -y \
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
 # Download our prebuilt version of Qt
-curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
-# Download our prebuilt version of QtWebkit
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-2/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,35 +12,46 @@ sudo apt-get install -y \
     libglib2.0-dev \
     libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev \
+    libharfbuzz-icu0 \
     libhyphen-dev \
     libicu-dev \
     libjpeg-dev \
     libpng-dev \
     libxslt1-dev \
+    libwebpdemux2 \
+    libwoff1 \
 
 # Install Qt
 sudo apt-get install -y \
-    qtbase5-dev \
-    qtdeclarative5-dev \
-    qtmultimedia5-dev \
-    qtpositioning5-dev \
-    libqt5sensors5-dev \
-    libqt5webchannel5 \
-    qt5-qmake \
+    libqt6core5compat6-dev \
+    libqt6sensors6-dev \
+    qt6-base-dev \
+    qt6-declarative-dev \
+    qt6-multimedia-dev \
+    qt6-positioning-dev \
+
+# Qt executables go through "qtchooser" by default. It is broken. Just replace the "qtchooser" versions with a link to the executable we actually want to run
+# If you see an error of "thng: could not find a Qt installation of ''" then that means that `thng` is another executable that needs the following treatment.
+sudo rm /usr/bin/qmake
+sudo ln -s /usr/lib/qt6/bin/qmake /usr/bin/qmake
+sudo rm /usr/bin/moc
+sudo ln -s /usr/lib/qt6/libexec/moc /usr/bin/moc
+sudo rm /usr/bin/uic
+sudo ln -s /usr/lib/qt6/libexec/uic /usr/bin/uic
 
 # Alias python3 to python so the build script can find it
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
 # Download our prebuilt version of QtWebkit
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
 
 # Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
-sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
-sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
-sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
-sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+sudo mv /usr/include/x86_64-linux-gnu/qt6/include/* /usr/include/x86_64-linux-gnu/qt6/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt6/include/
 
-sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
-sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/
+sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/cmake/
+sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/pkgconfig/
+sudo mv /usr/include/x86_64-linux-gnu/qt6/lib/* /usr/lib/x86_64-linux-gnu/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt6/lib/

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+sudo apt-get -y update 
+
+# Enable tab autocomplete in terminal
+sudo apt install bash-completion
+
+# Install tools required to build
+sudo apt-get install -y \
+    gyp \
+    libegl1-mesa-dev \
+    libglib2.0-dev \
+    libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev \
+    libhyphen-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libxslt1-dev \
+
+# Alias python3 to python so the build script can find it
+sudo ln -s /usr/bin/python3 /usr/bin/python
+
+# Download our prebuilt version of Qt
+curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar -xJC /opt
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,7 @@ jobs:
 
       - name: Install Qt
         run: |
-          curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
-
-      - name: Install Qtwebkit
-        run: |
-          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+          curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-2/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
 
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [WD_1.X_dev]
     paths-ignore:
       - '**/*.md'
   push:
@@ -11,20 +11,7 @@ on:
       - v*
 
 env:
-  QTVERSION: 5.15.0-lts
-  BUILD_CONFIG: "{
-      'variables': {
-        'QT5': '1',
-        'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '0',
-        'WD_CONFIG_QUICK': '1',
-        'WD_CONFIG_PLAYER': '0',
-        'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/opt/qt5/include',
-        'QT_BIN_PATH': '/opt/qt5/bin',
-        'QT_LIB_PATH': '/opt/qt5/lib'
-      },
-    }"
+  QTVERSION: 5.15.8-lts-lgpl
 
 jobs:
   tar-src:
@@ -76,25 +63,27 @@ jobs:
             libicu-dev \
             libjpeg-dev \
             libpng-dev \
+            libunwind-dev \
             libxslt1-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}x64.tar.gz | sudo tar -xJC /opt
+        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - name: Install Qtwebkit
         run: curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar xvJ -C /opt
       - name: checkout
         uses: actions/checkout@v4
-      - name: Configure
-        run: echo ${BUILDCONFIG} > wd.gypi
       - name: Build
-        run: build.sh
+        working-directory: ${{ github.workspace }}
+        run: ./build.sh
       - name: Archive
-        working-directory: ${{ github.workspace }}/opt
-        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
+        working-directory: ${{ github.workspace }}
+        run: |
+          mv out qtwebdriver
+          tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
-          path: "${{ github.workspace }}/opt/${{ steps.config.outputs.artefact_name }}"
+          path: "${{ github.workspace }}/${{ steps.config.outputs.artefact_name }}"
 
   release:
     if: contains(github.ref, 'tags/v')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,152 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+  push:
+    tags:
+      - v*
+
+env:
+  QTVERSION: 5.15.0-lts
+  BUILD_CONFIG: "{
+      'variables': {
+        'QT5': '1',
+        'WD_CONFIG_QWIDGET_BASE': '1',
+        'WD_CONFIG_WEBKIT': '0',
+        'WD_CONFIG_QUICK': '1',
+        'WD_CONFIG_PLAYER': '0',
+        'WD_CONFIG_ONE_KEYRELEASE': '0',
+        'QT_INC_PATH': '/opt/qt5/include',
+        'QT_BIN_PATH': '/opt/qt5/bin',
+        'QT_LIB_PATH': '/opt/qt5/lib'
+      },
+    }"
+
+jobs:
+  tar-src:
+    outputs:
+      short_version: ${{ steps.config.outputs.short_version }}
+
+    name: "Tar source"
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        run: |
+          echo "artefact_name=qtwebdriver-${QTVERSION}-src.tar.gz" >> $GITHUB_OUTPUT
+          echo "short_version=${QTVERSION}" >> $GITHUB_OUTPUT
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          path: qtwebdriver-src
+      - name: Archive
+        run: tar --create --xz --file "${{ steps.config.outputs.artefact_name }}" --exclude-vcs qtwebdriver-src
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ steps.config.outputs.artefact_name }}"
+          path: "${{ github.workspace }}/${{ steps.config.outputs.artefact_name }}"
+  
+  build:
+    name: "Build ${{ matrix.config.os }}"
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: "ubuntu-22.04"
+            std: "17"
+
+    steps:
+      - id: config
+        run: echo "artefact_name=qtwebdriver-${QTVERSION}-cpp${{ matrix.config.std }}-${{ matrix.config.os }}-x64.tar.gz" >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y \
+            gyp \
+            libegl1-mesa-dev \
+            libglib2.0-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libhyphen-dev \
+            libicu-dev \
+            libjpeg-dev \
+            libpng-dev \
+            libxslt1-dev \
+      - name: Install Qt
+        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}x64.tar.gz | sudo tar -xJC /opt
+      - name: Install Qtwebkit
+        run: curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar xvJ -C /opt
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Configure
+        run: echo ${BUILDCONFIG} > wd.gypi
+      - name: Build
+        run: build.sh
+      - name: Archive
+        working-directory: ${{ github.workspace }}/opt
+        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ steps.config.outputs.artefact_name }}"
+          path: "${{ github.workspace }}/opt/${{ steps.config.outputs.artefact_name }}"
+
+  release:
+    if: contains(github.ref, 'tags/v')
+
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs:
+      - tar-src
+      - build
+
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+  upload:
+    if: contains(github.ref, 'tags/v')
+
+    name: "Upload ${{ matrix.config.artefact }} to release"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - artefact: qtwebdriver-${{ needs.tar-src.outputs.short_version }}-src.tar.gz
+          - artefact: qtwebdriver-${{ needs.tar-src.outputs.short_version }}-cpp17-ubuntu-22.04-x64.tar.gz
+    needs:
+      - tar-src
+      - release
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ matrix.config.artefact }}"
+          path: ./
+      - name: Upload to Release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: "./${{ matrix.config.artefact }}"
+          asset_name: "${{ matrix.config.artefact }}"
+          asset_content_type: application/x-gtar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ on:
       - v*
 
 env:
-  QTVERSION: 5.15.8-lts-lgpl
+  # 5.15.3 is the version of Qt you get when you install qt5 libraries via `apt install`
+  QTVERSION: 5.15.3
 
 jobs:
   tar-src:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ on:
       - v*
 
 env:
-  # 5.15.3 is the version of Qt you get when you install qt5 libraries via `apt install`
-  QTVERSION: 5.15.3
+  # 6.7.1 is the latest version of Qt we have built
+  QTVERSION: 6.7.1
 
 jobs:
   tar-src:
@@ -53,55 +53,46 @@ jobs:
         run: echo "artefact_name=qtwebdriver-${QTVERSION}-cpp${{ matrix.config.std }}-${{ matrix.config.os }}-x64.tar.gz" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y \
+          sudo apt -o Acquire::Retries=3 update
+          sudo apt -o Acquire::Retries=3 install -y \
             gyp \
+            libdbus-1-dev \
             libegl1-mesa-dev \
             libglib2.0-dev \
             libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev \
+            libharfbuzz-icu0 \
             libhyphen-dev \
             libicu-dev \
             libjpeg-dev \
             libpng-dev \
             libunwind-dev \
             libxslt1-dev \
+            libwebpdemux2 \
+            libwoff1 \
+            libxkbcommon-dev
+
       - name: Install Qt
         run: |
-          sudo apt-get -o Acquire::Retries=3 install -y \
-            qtbase5-dev \
-            qtdeclarative5-dev \
-            qtmultimedia5-dev \
-            qtpositioning5-dev \
-            libqt5sensors5-dev \
-            libqt5webchannel5 \
-            qt5-qmake \
+          curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+
       - name: Install Qtwebkit
         run: |
-          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
-          
-          # Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
-          sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
-          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
+          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
 
-          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
-          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
-
-          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
-          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
-          
-          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
-          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/
       - name: checkout
         uses: actions/checkout@v4
+
       - name: Build
         working-directory: ${{ github.workspace }}
         run: ./build.sh
+
       - name: Archive
         working-directory: ${{ github.workspace }}
         run: |
           mv out qtwebdriver
           tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
+
       - name: Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,31 @@ jobs:
             libunwind-dev \
             libxslt1-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
+        run: |
+          sudo apt-get -o Acquire::Retries=3 install -y \
+            qtbase5-dev \
+            qtdeclarative5-dev \
+            qtmultimedia5-dev \
+            qtpositioning5-dev \
+            libqt5sensors5-dev \
+            libqt5webchannel5 \
+            qt5-qmake \
       - name: Install Qtwebkit
-        run: curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar xvJ -C /opt
+        run: |
+          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
+          
+          # Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
+
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
+
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
+          
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/
       - name: checkout
         uses: actions/checkout@v4
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ report/*
 /build/
 /docs/
 /mocs/
-wd.gypi
 /wd.Makefile
 /Makefile
 /WebDriver.target.mk

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,30 @@
-# Synopsis
+# Description
+
+This Repo contains a fork of the QtWebDriver source code. We need this because the automated Robot tests in boron use it (and maybe a few other things?).
+
+This repo contains:
+- The source code for qtwebkit (originally from cisco)
+- A devcontainer that can be used for development/building of the source
+- A github action that automatically builds the code on pull requests, and builds a release when a version tag (`v1` or equivalent) is pushed.
+
+The intended usage is:
+1. make any changes you need
+2. (optional) use the devcontainer to confirm the builds succeed locally (open the dev container and run `build.sh`)
+3. create PR and get it approved
+4. push a version tag to create a release
+5. use the release build anywhere you need a qtwebdriver build
+
+To use the release, you can download it with a command that looks like the following:
+```bash
+curl -L https://github.com/constructpm/qtwebdriver/releases/download/v5.15.3-dev-1/qtwebdriver-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+```
+
+This process is intended to match the process used to get a build of Qt from [qt-build](https://github.com/constructpm/qt-build), and a build of QtWebkit from [qtwebkit-build](https://github.com/constructpm/qtwebkit-build) do.
+It replaces the old process of building the binary manually and placing it in a shared storage area.
+
+# Old Readme
+
+## Synopsis
 QtWebDriver is a WebDriver implementation for Qt.
 
 It can be used to perform automated Selenium testing of applications based on:
@@ -10,15 +36,15 @@ If you hadn't used Selenium for automated testing, you may also find this links 
 * https://github.com/seleniumhq/selenium
 * http://docs.seleniumhq.org/  
 
-# Build and run
+## Build and run
 * The build instructions are detailed in the wiki: https://github.com/cisco-open-source/qtwebdriver/wiki/Build-And-Run
 * Release notes and pre-built binaries are in the Releases section: https://github.com/cisco-open-source/qtwebdriver/releases
 
-# Other links
+## Other links
 * An example how to customize QtWebDriver in `src/Test/main.cc`   
 * [Doxygen](http://cisco-open-source.github.io/qtwebdriver/html)  
 * [Wiki](https://github.com/cisco-open-source/qtwebdriver/wiki)  
 * Mailing list: qtwebdriver-users@external.cisco.com
 
-# License
+## License
 LGPLv2.1

--- a/do_if_modified.py
+++ b/do_if_modified.py
@@ -3,8 +3,8 @@ import os
 import sys
 
 if (len(sys.argv) != 4):
-    print 'Wrong usage:'
-    print ' do_if_modified <bin_file> <input_file> <output_file>'
+    print('Wrong usage:')
+    print(' do_if_modified <bin_file> <input_file> <output_file>')
     exit()
 
 action_process = os.path.abspath(sys.argv[1])

--- a/generate_wdversion.py
+++ b/generate_wdversion.py
@@ -11,7 +11,7 @@ versionfile.write("extern const char kProductName[] = \"WebDriver-cisco-cmt\";\n
 versionfile.write("extern const char kVersionNumber[] = \"1.3.3\";\n")
 versionfile.write("extern const char kBuildTime[] = __TIME__;\n")
 versionfile.write("extern const char kBuildDate[] = __DATE__;\n")
-versionfile.write("extern const char kLastChanges[] = \"" + data.strip() + "\";\n")
+versionfile.write("extern const char kLastChanges[] = \"" + data.strip().decode() + "\";\n")
 versionfile.write("}")
 versionfile.close()
 

--- a/inc/extension_qt/q_view_executor.h
+++ b/inc/extension_qt/q_view_executor.h
@@ -32,7 +32,9 @@
 #include <QtCore/QDebug>
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWidgets/QWidget>
+#if (QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
 #include <QtGui/QTouchDevice>
+#endif
 #else
 #include <QtGui/QWidget>
 #endif
@@ -73,7 +75,7 @@ protected:
     QTouchEvent* createTouchEvent(QEvent::Type eventType, Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints);
     QTouchEvent* create2PointTouchEvent(QEvent::Type eventType, Qt::TouchPointStates touchPointStates, QPointF &point1, QPointF &point2);
     QTouchEvent::TouchPoint createTouchPointWithId(Qt::TouchPointState state, QPointF &point, int id);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
   QTouchDevice touchDevice;
 #endif
 

--- a/inc/extension_qt/qml_web_view_executor.h
+++ b/inc/extension_qt/qml_web_view_executor.h
@@ -159,7 +159,7 @@ public:
 protected:
     QDeclarativeWebView* getView(const ViewId& viewId, Error** error);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
     QTouchDevice touchDevice;
 #endif
 

--- a/inc/extension_qt/qwindow_view_executor.h
+++ b/inc/extension_qt/qwindow_view_executor.h
@@ -30,7 +30,9 @@
 
 #include <QtCore/QDebug>
 #include <QtGui/QTouchEvent>
+#if (QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
 #include <QtGui/QTouchDevice>
+#endif
 #include <QtGui/QWindow>
 
 namespace webdriver {
@@ -70,7 +72,9 @@ protected:
     QTouchEvent* createTouchEvent(QEvent::Type eventType, Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints);
 
 private:
+#if (QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
     QTouchDevice touchDevice;
+#endif
     DISALLOW_COPY_AND_ASSIGN(QWindowViewCmdExecutor);
 };
 

--- a/inc/extension_qt/widget_view_handle.h
+++ b/inc/extension_qt/widget_view_handle.h
@@ -12,12 +12,22 @@
 #include <QtCore/QPointer>
 
 #include <QtCore/QtGlobal>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+#include <QtWidgets/QWidget>
+#include <QtGui/QAction>
+
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+
 #include <QtWidgets/QWidget>
 #include <QtWidgets/QAction>
+
 #else
+
 #include <QtGui/QWidget>
 #include <QtGui/QAction>
+
 #endif
 
 namespace webdriver {

--- a/src/Test/CommonQtTestHeaders.h
+++ b/src/Test/CommonQtTestHeaders.h
@@ -24,7 +24,28 @@
 #include <QtCore/QDebug>
 #include <QtCore/QMimeData>
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QWidget>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QScrollArea>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QTextEdit>
+#include <QtWidgets/QLayout>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPlainTextEdit>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtGui/QAction>
+#include <QtWidgets/QMenuBar>
+#include <QtWidgets/QMenu>
+#include <QtGui/QDragEnterEvent>
+#include <QtGui/QDropEvent>
+#include <QtGui/QDragMoveEvent>
+#include <QtGui/QDrag>
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QWidget>
 #include <QtWidgets/QPushButton>

--- a/src/Test/ElementAttributeTest.cc
+++ b/src/Test/ElementAttributeTest.cc
@@ -71,7 +71,12 @@ ElementAttributeTestWidget::ElementAttributeTestWidget() :
     pradioBtnBlue->setObjectName("defaultSelected");
 
     QPalette* palette1 = new QPalette();
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    palette1->setColor(QPalette::WindowText,Qt::darkBlue);
+#else
     palette1->setColor(QPalette::Foreground,Qt::darkBlue);
+#endif
     pradioBtnBlue->setPalette(*palette1);
     pradioBtnBlue->setStyleSheet("background-color: blue");
 

--- a/src/Test/Headers.h
+++ b/src/Test/Headers.h
@@ -21,7 +21,11 @@
 #define WD_SETUP_H
 
 #include <QtCore/QObject>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtCore5Compat/QTextCodec>
+#else
 #include <QtCore/QTextCodec>
+#endif
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     #include <QtConcurrent/QtConcurrentRun>

--- a/src/Test/VideoTest.cc
+++ b/src/Test/VideoTest.cc
@@ -19,6 +19,7 @@
 
 #include "VideoTest.h"
 #include <string>
+#include <QtMultimedia/QMediaMetaData>
 
 std::string testDataFolder;
 
@@ -28,7 +29,11 @@ VideoTestWidget::VideoTestWidget(QWidget *parent) :
     this->setGeometry(0, 0, 600, 400);
     this->setMinimumSize(400, 400);
     this->setMaximumSize(800, 800);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    mediaPlayer = new QMediaPlayer(NULL);
+#else
     mediaPlayer = new QMediaPlayer(NULL, QMediaPlayer::VideoSurface);
+#endif
     videoWidget = new QVideoWidget();
     videoWidget->setObjectName("videoPlayer");
 
@@ -73,12 +78,22 @@ VideoTestWidget::VideoTestWidget(QWidget *parent) :
 
     QUrl videoUrl = QUrl::fromLocalFile(videoPath);
     if (!videoUrl.isEmpty() && videoUrl.isValid()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        mediaPlayer->setSource(videoUrl);
+#else
         mediaPlayer->setMedia(videoUrl);
+#endif
         durationChanged(mediaPlayer->duration());
         positionChanged(mediaPlayer->position());
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         volumeChanged(mediaPlayer->volume());
+#endif
         playButton->setEnabled(true);
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QSize resolution = mediaPlayer->metaData()[QMediaMetaData::Resolution].toSize();
+#else
         QSize resolution = mediaPlayer->media().canonicalResource().resolution();
+#endif
         this->setGeometry(0,0, resolution.width(), resolution.height());
     }
 
@@ -92,7 +107,11 @@ VideoTestWidget::~VideoTestWidget()
 
 void VideoTestWidget::play()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    if(mediaPlayer->playbackState() == QMediaPlayer::PlayingState){
+#else
     if(mediaPlayer->state() == QMediaPlayer::PlayingState){
+#endif
         mediaPlayer->pause();
         playButton->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
     } else {
@@ -101,10 +120,12 @@ void VideoTestWidget::play()
     }
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 void VideoTestWidget::setVolume(int volume)
 {
     mediaPlayer->setVolume(volume);
 }
+#endif
 
 void VideoTestWidget::setPlayingPosition(int pos)
 {

--- a/src/third_party/mimetypes-qt4/mimetypes/qmimeglobpattern.cpp
+++ b/src/third_party/mimetypes-qt4/mimetypes/qmimeglobpattern.cpp
@@ -41,7 +41,11 @@
 
 #include "qmimeglobpattern_p.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtCore5Compat/QRegExp>
+#else
 #include <QtCore/QRegExp>
+#endif
 #include <QtCore/QStringList>
 #include <QtCore/QDebug>
 

--- a/src/vnc/vncclient.cc
+++ b/src/vnc/vncclient.cc
@@ -584,7 +584,7 @@ void VNCClient::sendMouseEvent(QMouseEvent *mouse)
             case Qt::NoButton: break;
             case Qt::LeftButton: mouseBtn = mouseBtn | 0x01; break;
             case Qt::RightButton: mouseBtn = mouseBtn | 0x04; break;
-            case Qt::MidButton: mouseBtn = mouseBtn | 0x02; break;
+            case Qt::MiddleButton: mouseBtn = mouseBtn | 0x02; break;
             default: break;
         }
     }
@@ -595,7 +595,7 @@ void VNCClient::sendMouseEvent(QMouseEvent *mouse)
             case Qt::NoButton: break;
             case Qt::LeftButton: mouseBtn = mouseBtn & 0xfe; break;
             case Qt::RightButton: mouseBtn = mouseBtn & 0xfb; break;
-            case Qt::MidButton: mouseBtn = mouseBtn & 0xfd; break;
+            case Qt::MiddleButton: mouseBtn = mouseBtn & 0xfd; break;
             default: break;
         }
     }
@@ -633,7 +633,7 @@ void VNCClient::sendDoubleClick(QMouseEvent *event)
         case Qt::NoButton: break;
         case Qt::LeftButton: mouseBtn = mouseBtn | 0x01; break;
         case Qt::RightButton: mouseBtn = mouseBtn | 0x04; break;
-        case Qt::MidButton: mouseBtn = mouseBtn | 0x02; break;
+        case Qt::MiddleButton: mouseBtn = mouseBtn | 0x02; break;
         default: break;
     }
 
@@ -659,7 +659,7 @@ void VNCClient::sendDoubleClick(QMouseEvent *event)
         case Qt::NoButton: break;
         case Qt::LeftButton: mouseBtn = mouseBtn & 0xfe; break;
         case Qt::RightButton: mouseBtn = mouseBtn & 0xfb; break;
-        case Qt::MidButton: mouseBtn = mouseBtn & 0xfd; break;
+        case Qt::MiddleButton: mouseBtn = mouseBtn & 0xfd; break;
         default: break;
     }
 
@@ -671,7 +671,7 @@ void VNCClient::sendDoubleClick(QMouseEvent *event)
         case Qt::NoButton: break;
         case Qt::LeftButton: mouseBtn = mouseBtn | 0x01; break;
         case Qt::RightButton: mouseBtn = mouseBtn | 0x04; break;
-        case Qt::MidButton: mouseBtn = mouseBtn | 0x02; break;
+        case Qt::MiddleButton: mouseBtn = mouseBtn | 0x02; break;
         default: break;
     }
 
@@ -683,7 +683,7 @@ void VNCClient::sendDoubleClick(QMouseEvent *event)
         case Qt::NoButton: break;
         case Qt::LeftButton: mouseBtn = mouseBtn & 0xfe; break;
         case Qt::RightButton: mouseBtn = mouseBtn & 0xfb; break;
-        case Qt::MidButton: mouseBtn = mouseBtn & 0xfd; break;
+        case Qt::MiddleButton: mouseBtn = mouseBtn & 0xfd; break;
         default: break;
     }
 

--- a/src/vnc/vncclient.cc
+++ b/src/vnc/vncclient.cc
@@ -22,7 +22,11 @@
 
 #include <QtNetwork/QHostAddress>
 #include <QtCore/QMap>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtCore/QRegularExpression>
+#else
 #include <QtCore/QRegExp>
+#endif
 #include <QtCore/QStringList>
 
 #define MAJOR_INDEX 6
@@ -116,7 +120,11 @@ bool VNCClient::Init(QString remoteHost, quint16 port)
 
     if (!addr.setAddress(remoteHost))
     {
+        #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        remoteHost.replace(QRegularExpression("http*://"), "");
+        #else
         remoteHost.replace(QRegExp("http*://"), "");
+        #endif
         addr.setAddress(remoteHost);
     }
 
@@ -141,7 +149,11 @@ bool VNCClient::Init(QString remoteHost, quint16 port, QString* password)
 
     if (!addr.setAddress(remoteHost))
     {
+        #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        remoteHost.replace(QRegularExpression("http*://"), "");
+        #else
         remoteHost.replace(QRegExp("http*://"), "");
+        #endif
         addr.setAddress(remoteHost);
     }
 

--- a/src/webdriver/extension_qt/common_util.cc
+++ b/src/webdriver/extension_qt/common_util.cc
@@ -57,7 +57,7 @@ Qt::MouseButton QCommonUtil::ConvertMouseButtonToQtMouseButton(MouseButton butto
     switch(button)
     {
         case kLeftButton: result = Qt::LeftButton; break;
-        case kMiddleButton: result = Qt::MidButton; break;
+        case kMiddleButton: result = Qt::MiddleButton; break;
         case kRightButton: result = Qt::RightButton; break;
         default: result = Qt::NoButton;
     }

--- a/src/webdriver/extension_qt/graphics_web_view_executor.cc
+++ b/src/webdriver/extension_qt/graphics_web_view_executor.cc
@@ -375,7 +375,12 @@ void GraphicsWebViewCmdExecutor::MouseWheel(const int delta, Error** error) {
 
     QPoint point = QCommonUtil::ConvertPointToQPoint(session_->get_mouse_position());
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint globalPos = point; // QGraphicsWebView doesn't provide and obvious function for converting from localSpace to globalSpace
+    QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, QPoint(0, 0), QPoint(0, delta), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(point, delta, Qt::NoButton, Qt::NoModifier);
+#endif
 
     QApplication::postEvent(view_->page(), wheelEvent);
 }

--- a/src/webdriver/extension_qt/graphics_web_view_executor.cc
+++ b/src/webdriver/extension_qt/graphics_web_view_executor.cc
@@ -251,7 +251,7 @@ void GraphicsWebViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
     CHECK_VIEW_EXISTANCE
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = session_->get_sticky_modifiers();
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -267,7 +267,7 @@ void GraphicsWebViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
     session_->set_sticky_modifiers(modifiers);
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
 
         bool consumed = WDEventDispatcher::getInstance()->dispatch(&(*it));
@@ -306,7 +306,7 @@ void GraphicsWebViewCmdExecutor::SendKeys(const ElementId& element, const string
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -320,7 +320,7 @@ void GraphicsWebViewCmdExecutor::SendKeys(const ElementId& element, const string
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         qApp->sendEvent(view_->page(), &(*it));
         ++it;

--- a/src/webdriver/extension_qt/q_key_converter.cc
+++ b/src/webdriver/extension_qt/q_key_converter.cc
@@ -163,9 +163,9 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
                                const Logger& logger,
                                bool release_modifiers,
                                int* modifiers,
-                               std::vector<QKeyEvent>* client_key_events,
+                               std::list<QKeyEvent>* client_key_events,
                                std::string* error_msg) {
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
 
     string16 keys = client_keys;
     // Add an implicit NULL character to the end of the input to depress all
@@ -182,17 +182,13 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
         if (key == kWebDriverNullKey) {
             // Release all modifier keys and clear |stick_modifiers|.
             if (sticky_modifiers & Qt::ShiftModifier)
-                key_events.push_back(
-                    QKeyEvent(QEvent::KeyRelease, Qt::Key_Shift, Qt::NoModifier));
+                key_events.emplace_back(QEvent::KeyRelease, Qt::Key_Shift, Qt::NoModifier);
             if (sticky_modifiers & Qt::ControlModifier)
-                key_events.push_back(
-                    QKeyEvent(QEvent::KeyRelease, Qt::Key_Control, Qt::NoModifier));
+                key_events.emplace_back(QEvent::KeyRelease, Qt::Key_Control, Qt::NoModifier);
             if (sticky_modifiers & Qt::AltModifier)
-                key_events.push_back(
-                    QKeyEvent(QEvent::KeyRelease, Qt::Key_Alt, Qt::NoModifier));
+                key_events.emplace_back(QEvent::KeyRelease, Qt::Key_Alt, Qt::NoModifier);
             if (sticky_modifiers & Qt::MetaModifier)
-                key_events.push_back(
-                    QKeyEvent(QEvent::KeyRelease, Qt::Key_Meta, Qt::NoModifier));
+                key_events.emplace_back(QEvent::KeyRelease, Qt::Key_Meta, Qt::NoModifier);
             sticky_modifiers = Qt::NoModifier;
             continue;
         }
@@ -222,11 +218,9 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
                 NOTREACHED();
             }
             if (modifier_down)
-                key_events.push_back(
-                        QKeyEvent(QEvent::KeyPress, key_code, sticky_modifiers));
+                key_events.emplace_back(QEvent::KeyPress, key_code, sticky_modifiers);
             else
-                key_events.push_back(
-                        QKeyEvent(QEvent::KeyRelease, key_code, sticky_modifiers));
+                key_events.emplace_back(QEvent::KeyRelease, key_code, sticky_modifiers);
             continue;
         }
 
@@ -314,22 +308,21 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
                 all_modifiers & kModifiers[i].mask &&
                 !(sticky_modifiers & kModifiers[i].mask);
             if (necessary_modifiers[i]) {
-                key_events.push_back(
-                    QKeyEvent(QEvent::KeyPress, kModifiers[i].key_code, sticky_modifiers, QString(), autoPress));
+                key_events.emplace_back(QEvent::KeyPress, kModifiers[i].key_code, sticky_modifiers, QString(), autoPress);
             }
         }
 
         if (unmodified_text.length() || modified_text.length()) {
-            key_events.push_back(QKeyEvent(QEvent::KeyPress, key_code, all_modifiers, unmodified_text.c_str(), autoPress));
+            key_events.emplace_back(QEvent::KeyPress, key_code, all_modifiers, unmodified_text.c_str(), autoPress);
             if (sendRelease) {
-                key_events.push_back(QKeyEvent(QEvent::KeyRelease, key_code, all_modifiers, unmodified_text.c_str(), autoRelease));      
+                key_events.emplace_back(QEvent::KeyRelease, key_code, all_modifiers, unmodified_text.c_str(), autoRelease);      
             }
         }
         else
         {
-            key_events.push_back(QKeyEvent(QEvent::KeyPress, key_code, all_modifiers, QString(), autoPress));
+            key_events.emplace_back(QEvent::KeyPress, key_code, all_modifiers, QString(), autoPress);
             if (sendRelease) {
-                key_events.push_back(QKeyEvent(QEvent::KeyRelease, key_code, all_modifiers, QString(), autoRelease));
+                key_events.emplace_back(QEvent::KeyRelease, key_code, all_modifiers, QString(), autoRelease);
             }
         }
 
@@ -337,8 +330,7 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
         if (sendRelease) {
             for (int i = 2; i > -1; --i) {
                 if (necessary_modifiers[i]) {
-                    key_events.push_back(
-                        QKeyEvent(QEvent::KeyRelease, kModifiers[i].key_code, sticky_modifiers, QString(), autoRelease));
+                    key_events.emplace_back(QEvent::KeyRelease, kModifiers[i].key_code, sticky_modifiers, QString(), autoRelease);
                 }
             }
         }

--- a/src/webdriver/extension_qt/q_key_converter.cc
+++ b/src/webdriver/extension_qt/q_key_converter.cc
@@ -315,7 +315,7 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
                 !(sticky_modifiers & kModifiers[i].mask);
             if (necessary_modifiers[i]) {
                 key_events.push_back(
-                    QKeyEvent(QEvent::KeyPress, kModifiers[i].key_code, sticky_modifiers, QString::null, autoPress));
+                    QKeyEvent(QEvent::KeyPress, kModifiers[i].key_code, sticky_modifiers, QString(), autoPress));
             }
         }
 
@@ -327,9 +327,9 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
         }
         else
         {
-            key_events.push_back(QKeyEvent(QEvent::KeyPress, key_code, all_modifiers, QString::null, autoPress));
+            key_events.push_back(QKeyEvent(QEvent::KeyPress, key_code, all_modifiers, QString(), autoPress));
             if (sendRelease) {
-                key_events.push_back(QKeyEvent(QEvent::KeyRelease, key_code, all_modifiers, QString::null, autoRelease));
+                key_events.push_back(QKeyEvent(QEvent::KeyRelease, key_code, all_modifiers, QString(), autoRelease));
             }
         }
 
@@ -338,7 +338,7 @@ bool QKeyConverter::ConvertKeysToWebKeyEvents(const string16& client_keys,
             for (int i = 2; i > -1; --i) {
                 if (necessary_modifiers[i]) {
                     key_events.push_back(
-                        QKeyEvent(QEvent::KeyRelease, kModifiers[i].key_code, sticky_modifiers, QString::null, autoRelease));
+                        QKeyEvent(QEvent::KeyRelease, kModifiers[i].key_code, sticky_modifiers, QString(), autoRelease));
                 }
             }
         }

--- a/src/webdriver/extension_qt/q_key_converter.h
+++ b/src/webdriver/extension_qt/q_key_converter.h
@@ -29,7 +29,7 @@ public:
                                const Logger& logger,
                                bool release_modifiers,
                                int* modifiers,
-                               std::vector<QKeyEvent>* client_key_events,
+                               std::list<QKeyEvent>* client_key_events,
                                std::string* error_msg);
 private:
     QKeyConverter() {};

--- a/src/webdriver/extension_qt/q_proxy_parser.cc
+++ b/src/webdriver/extension_qt/q_proxy_parser.cc
@@ -199,7 +199,7 @@ Error* QProxyCapabilitiesParser::ParseNoProxy(const base::Value* option){
 Error* QProxyCapabilitiesParser::ParseSystemProxy(const base::DictionaryValue *options) {
 
     QString urlString(qgetenv("http_proxy"));
-    if (urlString == NULL) {
+    if (urlString.isEmpty()) {
         logger_.Log(kInfoLogLevel,"system proxy configuration not found");
         return NULL;
     }

--- a/src/webdriver/extension_qt/q_view_executor.cc
+++ b/src/webdriver/extension_qt/q_view_executor.cc
@@ -367,10 +367,29 @@ void QViewCmdExecutor::GetOrientation(std::string *orientation, Error **error)
 
 QTouchEvent::TouchPoint QViewCmdExecutor::createTouchPoint(Qt::TouchPointState state, QPointF &point)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QEventPoint::State convertedState = QEventPoint::Unknown;
+    switch(state) {
+        case Qt::TouchPointPressed:
+            convertedState = QEventPoint::Pressed;
+            break;
+        case Qt::TouchPointMoved:
+            convertedState = QEventPoint::Updated;
+            break;
+        case Qt::TouchPointStationary:
+            convertedState = QEventPoint::Stationary;
+            break;
+        case Qt::TouchPointReleased:
+            convertedState = QEventPoint::Released;
+            break;
+    }
+    QTouchEvent::TouchPoint touchPoint(1, convertedState, point, point);
+#else
     QTouchEvent::TouchPoint touchPoint(1);
     touchPoint.setPos(point);
     touchPoint.setState(state);
     touchPoint.setPressure(1);
+#endif
     return touchPoint;
 }
 
@@ -392,7 +411,10 @@ QTouchEvent* QViewCmdExecutor::createSimpleTouchEvent(QEvent::Type eventType, Qt
 
 QTouchEvent* QViewCmdExecutor::createTouchEvent(QEvent::Type eventType, Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QTouchEvent *touchEvent = new QTouchEvent(eventType, nullptr, Qt::NoModifier, touchPoints);
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     QTouchEvent *touchEvent = new QTouchEvent(eventType, &touchDevice, Qt::NoModifier, touchPointStates, touchPoints);
     QDateTime current = QDateTime::currentDateTime();
     ulong timestame = current.toMSecsSinceEpoch() & (((qint64)1<<(sizeof(ulong)*8))-1);
@@ -423,10 +445,29 @@ QTouchEvent* QViewCmdExecutor::create2PointTouchEvent(QEvent::Type eventType, Qt
 
 QTouchEvent::TouchPoint QViewCmdExecutor::createTouchPointWithId(Qt::TouchPointState state, QPointF &point, int id)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QEventPoint::State convertedState = QEventPoint::Unknown;
+    switch(state) {
+        case Qt::TouchPointPressed:
+            convertedState = QEventPoint::Pressed;
+            break;
+        case Qt::TouchPointMoved:
+            convertedState = QEventPoint::Updated;
+            break;
+        case Qt::TouchPointStationary:
+            convertedState = QEventPoint::Stationary;
+            break;
+        case Qt::TouchPointReleased:
+            convertedState = QEventPoint::Released;
+            break;
+    }
+    QTouchEvent::TouchPoint touchPoint(id, convertedState, point, point);
+#else
     QTouchEvent::TouchPoint touchPoint(id);
     touchPoint.setPos(point);
     touchPoint.setState(state);
     touchPoint.setPressure(1);
+#endif
 
     return touchPoint;
 }

--- a/src/webdriver/extension_qt/q_view_executor.cc
+++ b/src/webdriver/extension_qt/q_view_executor.cc
@@ -31,7 +31,9 @@
 #include <QtCore/QDebug>
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWidgets/QApplication>
+#if (QT_VERSION <= QT_VERSION_CHECK(6, 0, 0))
 #include <QtWidgets/QDesktopWidget>
+#endif
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QInputDialog>
 #include <QtCore/QDateTime>
@@ -121,7 +123,7 @@ void QViewCmdExecutor::Maximize(Error** error) {
         return;
     }
 
-    view->setGeometry(QApplication::desktop()->rect());    
+    view->setGeometry(QGuiApplication::primaryScreen()->geometry());
 }
 
 void QViewCmdExecutor::GetScreenShot(std::string* png, Error** error) {

--- a/src/webdriver/extension_qt/q_view_executor.cc
+++ b/src/webdriver/extension_qt/q_view_executor.cc
@@ -169,7 +169,7 @@ void QViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = session_->get_sticky_modifiers();
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -185,7 +185,7 @@ void QViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
     session_->set_sticky_modifiers(modifiers);
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
 
         bool consumed = WDEventDispatcher::getInstance()->dispatch(&(*it));

--- a/src/webdriver/extension_qt/qml_view_executor.cc
+++ b/src/webdriver/extension_qt/qml_view_executor.cc
@@ -341,7 +341,11 @@ void QQmlViewCmdExecutor::MouseWheel(const int delta, Error **error) {
 
     session_->logger().Log(kFineLogLevel, base::StringPrintf("MouseWheel, screen: (%4d, %4d)", screenPos.x(), screenPos.y()));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QWheelEvent *wheelEvent = new QWheelEvent(viewPos, screenPos, QPoint(0, 0), QPoint(0, delta), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(viewPos, screenPos, delta, Qt::NoButton, Qt::NoModifier);
+#endif
 
     QApplication::postEvent(view->viewport(), wheelEvent);
 }

--- a/src/webdriver/extension_qt/qml_view_executor.cc
+++ b/src/webdriver/extension_qt/qml_view_executor.cc
@@ -164,7 +164,7 @@ void QQmlViewCmdExecutor::SendKeys(const ElementId& element, const string16& key
     }
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -188,7 +188,7 @@ void QQmlViewCmdExecutor::SendKeys(const ElementId& element, const string16& key
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         qApp->sendEvent(view, &(*it));
         ++it;

--- a/src/webdriver/extension_qt/qml_view_util.cc
+++ b/src/webdriver/extension_qt/qml_view_util.cc
@@ -26,7 +26,12 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtCore/QFileInfo>
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include "extension_qt/qwindow_view_handle.h"
+#include <QtQuick/QQuickView>
+//#include <QtQuick/QQuickItem>
+#include <QtCore/QRegularExpression>
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include "extension_qt/qwindow_view_handle.h"
 #include <QtQuick/QQuickView>
 //#include <QtQuick/QQuickItem>
@@ -77,8 +82,13 @@ bool QQmlViewUtil::isContentTypeSupported(const std::string& mime) {
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 void QQmlViewUtil::removeInternalSuffixes(QString& str) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    str.remove(QRegularExpression(QLatin1String("_QMLTYPE_\\d+")));
+    str.remove(QRegularExpression(QLatin1String("_QML_\\d+")));
+#else
     str.remove(QRegExp(QLatin1String("_QMLTYPE_\\d+")));
     str.remove(QRegExp(QLatin1String("_QML_\\d+")));
+#endif
     if (str.startsWith(QLatin1String("QQuick"))) str = str.mid(6);
 }
 

--- a/src/webdriver/extension_qt/qml_web_view_executor.cc
+++ b/src/webdriver/extension_qt/qml_web_view_executor.cc
@@ -217,7 +217,7 @@ void QmlWebViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
     CHECK_VIEW_EXISTANCE
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = session_->get_sticky_modifiers();
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -233,7 +233,7 @@ void QmlWebViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
     session_->set_sticky_modifiers(modifiers);
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
 
         bool consumed = WDEventDispatcher::getInstance()->dispatch(&(*it));
@@ -272,7 +272,7 @@ void QmlWebViewCmdExecutor::SendKeys(const ElementId& element, const string16& k
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -286,7 +286,7 @@ void QmlWebViewCmdExecutor::SendKeys(const ElementId& element, const string16& k
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         qApp->sendEvent(view_->page(), &(*it));
         ++it;

--- a/src/webdriver/extension_qt/qml_web_view_executor.cc
+++ b/src/webdriver/extension_qt/qml_web_view_executor.cc
@@ -341,7 +341,12 @@ void QmlWebViewCmdExecutor::MouseWheel(const int delta, Error **error) {
 
     QPoint point = QCommonUtil::ConvertPointToQPoint(session_->get_mouse_position());
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QPoint globalPos = view_->mapToGlobal(point);
+    QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, QPoint(0, 0), QPoint(0, delta), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(point, delta, Qt::NoButton, Qt::NoModifier);
+#endif
 
     QApplication::postEvent(view_->page(), wheelEvent);
 }

--- a/src/webdriver/extension_qt/quick2_view_executor.cc
+++ b/src/webdriver/extension_qt/quick2_view_executor.cc
@@ -183,7 +183,7 @@ void Quick2ViewCmdExecutor::SendKeys(const ElementId& element, const string16& k
 
     std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
-        view->sendEvent(pItem, &(*it));
+        QCoreApplication::sendEvent(pItem, &(*it));
         ++it;
     }
 }
@@ -219,7 +219,7 @@ void Quick2ViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
         if (!consumed) {
             if (NULL != pFocusItem) {
-                view->sendEvent(pFocusItem, &(*it));
+                QCoreApplication::sendEvent(pFocusItem, &(*it));
             } else {
                 QGuiApplication::sendEvent(view, &(*it));
             }

--- a/src/webdriver/extension_qt/quick2_view_executor.cc
+++ b/src/webdriver/extension_qt/quick2_view_executor.cc
@@ -167,7 +167,7 @@ void Quick2ViewCmdExecutor::SendKeys(const ElementId& element, const string16& k
     }
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -181,7 +181,7 @@ void Quick2ViewCmdExecutor::SendKeys(const ElementId& element, const string16& k
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         view->sendEvent(pItem, &(*it));
         ++it;
@@ -194,7 +194,7 @@ void Quick2ViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = session_->get_sticky_modifiers();
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -212,7 +212,7 @@ void Quick2ViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
     session_->set_sticky_modifiers(modifiers);
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
 
         bool consumed = WDEventDispatcher::getInstance()->dispatch(&(*it));

--- a/src/webdriver/extension_qt/quick2_view_executor.cc
+++ b/src/webdriver/extension_qt/quick2_view_executor.cc
@@ -359,6 +359,9 @@ void Quick2ViewCmdExecutor::MouseWheel(const int delta, Error **error) {
 
     QPoint angleDelta(0, delta);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QWheelEvent *wheelEvent = new QWheelEvent(scenePoint, screenPos, pixelDelta, angleDelta, Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(scenePoint,
                                               screenPos,
                                               pixelDelta,
@@ -367,6 +370,7 @@ void Quick2ViewCmdExecutor::MouseWheel(const int delta, Error **error) {
                                               Qt::Vertical,
                                               Qt::NoButton,
                                               Qt::NoModifier);
+#endif
 
     QGuiApplication::postEvent(view, wheelEvent);
 }

--- a/src/webdriver/extension_qt/qwebkit_proxy.cc
+++ b/src/webdriver/extension_qt/qwebkit_proxy.cc
@@ -167,7 +167,8 @@ void JSLogger::error(QVariant message) {
 
 QWebkitProxy::QWebkitProxy(Session* session, QWebPage* webpage) :
 				session_(session),
-				page_(webpage) {}
+				page_(webpage),
+				online_(false) {}
 
 QWebkitProxy::~QWebkitProxy() {}
 
@@ -1230,12 +1231,16 @@ Error* QWebkitProxy::GetMute(const ElementId& element, bool* mute) {
 
 Error* QWebkitProxy::SetOnline(bool online) {
 #ifndef QT_NO_BEARERMANAGEMENT
+    online_ = online;
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     QNetworkAccessManager *manager = page_->networkAccessManager();
-    if (online){
+
+    if (online_){
         manager->setNetworkAccessible(QNetworkAccessManager::Accessible);
     } else {
         manager->setNetworkAccessible(QNetworkAccessManager::NotAccessible);
     }
+#endif
     return NULL;
 #else
     session_->logger().Log(kWarningLogLevel, "In QWebkitProxy::SetOnline() defined QT_NO_BEARERMANAGEMENT");
@@ -1245,12 +1250,16 @@ Error* QWebkitProxy::SetOnline(bool online) {
 
 Error* QWebkitProxy::IsOnline(bool* online) {
 #ifndef QT_NO_BEARERMANAGEMENT
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    *online = online_;
+#else
     QNetworkAccessManager *manager = page_->networkAccessManager();
     if (manager->networkAccessible() == QNetworkAccessManager::NotAccessible) {
         *online = false;
     } else {
         *online = true;
     }
+#endif
     return NULL;
 #else
     session_->logger().Log(kWarningLogLevel, "In QWebkitProxy::IsOnline() defined QT_NO_BEARERMANAGEMENT");

--- a/src/webdriver/extension_qt/qwebkit_proxy.cc
+++ b/src/webdriver/extension_qt/qwebkit_proxy.cc
@@ -720,7 +720,11 @@ Error* QWebkitProxy::GetCookies(const std::string& url, base::ListValue** cookie
         cookie_dict->SetBoolean("secure", cookie.isSecure());
         cookie_dict->SetBoolean("http_only", cookie.isHttpOnly());
         if (!cookie.isSessionCookie())
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+            cookie_dict->SetDouble("expiry", (double)cookie.expirationDate().toSecsSinceEpoch());
+#else
             cookie_dict->SetDouble("expiry", (double)cookie.expirationDate().toTime_t());
+#endif
 
         list->Append(cookie_dict);
     }
@@ -790,7 +794,11 @@ Error* QWebkitProxy::SetCookie(const std::string& url, base::DictionaryValue* co
         //qDebug()<<"[WD]:" << "time=[" << time <<"]";
 
         QDateTime qtime;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        qtime.setSecsSinceEpoch(time);
+#else
         qtime.setTime_t(time);
+#endif
 
         if (qtime > QDateTime::currentDateTime()) {
             session_->logger().Log(kFineLogLevel, "SetCookie - adding cookie");

--- a/src/webdriver/extension_qt/qwebkit_proxy.h
+++ b/src/webdriver/extension_qt/qwebkit_proxy.h
@@ -204,6 +204,7 @@ public:
 protected:
     Session* session_;
     QWebPage* page_;
+    bool online_;
 
     QWebFrame* FindFrameByMeta(QWebFrame* parent, const FramePath &frame_path);
     QWebFrame* FindFrameByPath(QWebFrame* parent, const FramePath &frame_path);

--- a/src/webdriver/extension_qt/qwindow_view_executor.cc
+++ b/src/webdriver/extension_qt/qwindow_view_executor.cc
@@ -258,7 +258,7 @@ Qt::MouseButton QWindowViewCmdExecutor::ConvertMouseButtonToQtMouseButton(MouseB
     switch(button)
     {
         case kLeftButton: result = Qt::LeftButton; break;
-        case kMiddleButton: result = Qt::MidButton; break;
+        case kMiddleButton: result = Qt::MiddleButton; break;
         case kRightButton: result = Qt::RightButton; break;
         default: result = Qt::NoButton;
     }

--- a/src/webdriver/extension_qt/qwindow_view_executor.cc
+++ b/src/webdriver/extension_qt/qwindow_view_executor.cc
@@ -107,7 +107,7 @@ void QWindowViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = session_->get_sticky_modifiers();
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -123,7 +123,7 @@ void QWindowViewCmdExecutor::SendKeys(const string16& keys, Error** error) {
 
     session_->set_sticky_modifiers(modifiers);
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
 
         bool consumed = WDEventDispatcher::getInstance()->dispatch(&(*it));

--- a/src/webdriver/extension_qt/web_view_executor.cc
+++ b/src/webdriver/extension_qt/web_view_executor.cc
@@ -249,7 +249,7 @@ void QWebViewCmdExecutor::SendKeys(const ElementId& element, const string16& key
         return;
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -263,7 +263,7 @@ void QWebViewCmdExecutor::SendKeys(const ElementId& element, const string16& key
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         qApp->sendEvent(view_, &(*it));
         ++it;

--- a/src/webdriver/extension_qt/web_view_executor.cc
+++ b/src/webdriver/extension_qt/web_view_executor.cc
@@ -339,7 +339,11 @@ void QWebViewCmdExecutor::MouseWheel(const int delta, Error **error) {
     session_->logger().Log(kFineLogLevel, base::StringPrintf("MouseWheel, screen: (%4d, %4d)", globalPos.x(), globalPos.y()));
 
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, QPoint(0, 0), QPoint(0, delta), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, delta, Qt::NoButton, Qt::NoModifier);
+#endif
 
     QApplication::postEvent(view_, wheelEvent);
 }

--- a/src/webdriver/extension_qt/web_view_visualizer.cc
+++ b/src/webdriver/extension_qt/web_view_visualizer.cc
@@ -24,7 +24,11 @@
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
 #include <QtWebKit/QWebElement>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtWebKitWidgets/QWebFrame>
+#include <QtCore5Compat/QRegExp>
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWebKitWidgets/QWebFrame>
 #else
 #include <QtWebKit/QWebFrame>

--- a/src/webdriver/extension_qt/web_view_visualizer.cc
+++ b/src/webdriver/extension_qt/web_view_visualizer.cc
@@ -238,31 +238,6 @@ void QWebViewVisualizerSourceCommand::DownloadFinished() {
 
 const char QWebViewVisualizerSourceCommand::DATA_PROTOCOL[] = "data:";
 
-class QCursorMark : public QWidget
-{
-public:
-    explicit QCursorMark(QWidget* parent)
-        : QWidget(parent)
-    {
-        resize(2 * RADIUS, 2 * RADIUS);
-    }
-
-    virtual void paintEvent(QPaintEvent *event) {
-        QPainter painter(this);
-        painter.setPen(QPen(Qt::red));
-
-        QBrush brush = painter.brush();
-        brush.setColor(Qt::red);
-        brush.setStyle(Qt::SolidPattern);
-        painter.setBrush(brush);
-
-        painter.drawEllipse(QPoint(RADIUS, RADIUS), RADIUS, RADIUS);
-    }
-
-private:
-    static const int RADIUS = 5;
-};
-
 QWebViewVisualizerShowPointCommand::QWebViewVisualizerShowPointCommand(yasper::ptr<QWebkitProxy> webkitProxy, Session* session, QWebView* view)
     : webkitProxy_(webkitProxy), session_(session), view_(view)
 {}

--- a/src/webdriver/extension_qt/web_view_visualizer.h
+++ b/src/webdriver/extension_qt/web_view_visualizer.h
@@ -81,6 +81,32 @@ private:
     QWebView* view_;
 };
 
+class QCursorMark : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit QCursorMark(QWidget* parent)
+        : QWidget(parent)
+    {
+        resize(2 * RADIUS, 2 * RADIUS);
+    }
+
+    virtual void paintEvent(QPaintEvent *event) {
+        QPainter painter(this);
+        painter.setPen(QPen(Qt::red));
+
+        QBrush brush = painter.brush();
+        brush.setColor(Qt::red);
+        brush.setStyle(Qt::SolidPattern);
+        painter.setBrush(brush);
+
+        painter.drawEllipse(QPoint(RADIUS, RADIUS), RADIUS, RADIUS);
+    }
+
+private:
+    static const int RADIUS = 5;
+};
+
 }  // namespace webdriver
 
 #endif // WEB_VIEW_VISUALIZER_H

--- a/src/webdriver/extension_qt/widget_view_executor.cc
+++ b/src/webdriver/extension_qt/widget_view_executor.cc
@@ -186,7 +186,7 @@ void QWidgetViewCmdExecutor::SendKeys(const ElementId& element, const string16& 
     }
 
     std::string err_msg;
-    std::vector<QKeyEvent> key_events;
+    std::list<QKeyEvent> key_events;
     int modifiers = Qt::NoModifier;
 
     if (!QKeyConverter::ConvertKeysToWebKeyEvents(keys,
@@ -200,7 +200,7 @@ void QWidgetViewCmdExecutor::SendKeys(const ElementId& element, const string16& 
         return;
     }
 
-    std::vector<QKeyEvent>::iterator it = key_events.begin();
+    std::list<QKeyEvent>::iterator it = key_events.begin();
     while (it != key_events.end()) {
         qApp->sendEvent(pWidget, &(*it));
         ++it;

--- a/src/webdriver/extension_qt/widget_view_executor.cc
+++ b/src/webdriver/extension_qt/widget_view_executor.cc
@@ -38,7 +38,27 @@
 #include <QtCore/QBuffer>
 #include <QtCore/QDebug>
 #include <QtCore/QTimer>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPlainTextEdit>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QScrollArea>
+#include <QtWidgets/QProgressBar>
+#include <QtWidgets/QListView>
+#include <QtGui/QAction>
+#if (1 == WD_ENABLE_PLAYER)
+#include <QtMultimediaWidgets/QVideoWidget>
+#include <QtMultimedia/QMediaPlayer>
+#endif //WD_ENABLE_PLAYER
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QPlainTextEdit>

--- a/src/webdriver/extension_qt/widget_view_executor.cc
+++ b/src/webdriver/extension_qt/widget_view_executor.cc
@@ -394,7 +394,12 @@ void QWidgetViewCmdExecutor::MouseWheel(const int delta, Error **error){
     QPoint globalPos = receiverWidget->mapToGlobal(point);
     session_->logger().Log(kFineLogLevel, base::StringPrintf("MouseWheel, screen: (%4d, %4d)", globalPos.x(), globalPos.y()));
 
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, QPoint(0, 0), QPoint(0, delta), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+#else
     QWheelEvent *wheelEvent = new QWheelEvent(point, globalPos, delta, Qt::NoButton, Qt::NoModifier);
+#endif
 
     QApplication::postEvent(receiverWidget, wheelEvent);
 }

--- a/src/webdriver/webdriver_session.cc
+++ b/src/webdriver/webdriver_session.cc
@@ -501,13 +501,19 @@ void Session::UpdateViews(const std::set<ViewId>& views) {
     ViewsMap::iterator it;
     ViewId vi;
 
-    for (it = views_.begin(); it != views_.end(); ++it) {
+    for (it = views_.begin(); it != views_.end();) {
         vi = ViewId(it->first);
 		
         if (vi.is_valid() && 0 == views.count(vi)) {
+			it = views_.erase( it );
             // invalidate handle
             RemoveView(vi);
+			break;
         }
+		else
+		{
+			++it;
+		}
     }
 }
 

--- a/wd.gypi
+++ b/wd.gypi
@@ -2,7 +2,7 @@
     'variables': {
         'QT6': '1',
         'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '1',
+        'WD_CONFIG_WEBKIT': '0',
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',

--- a/wd.gypi
+++ b/wd.gypi
@@ -1,0 +1,13 @@
+{
+    'variables': {
+        'QT5': '1',
+        'WD_CONFIG_QWIDGET_BASE': '1',
+        'WD_CONFIG_WEBKIT': '0',
+        'WD_CONFIG_QUICK': '1',
+        'WD_CONFIG_PLAYER': '0',
+        'WD_CONFIG_ONE_KEYRELEASE': '0',
+        'QT_INC_PATH': '/opt/qt5/include',
+        'QT_BIN_PATH': '/opt/qt5/bin',
+        'QT_LIB_PATH': '/opt/qt5/lib'
+    },
+}

--- a/wd.gypi
+++ b/wd.gypi
@@ -6,8 +6,8 @@
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/usr/include/x86_64-linux-gnu/qt6',
-        'QT_BIN_PATH': '/usr/bin',
-        'QT_LIB_PATH': '/usr/lib/x86_64-linux-gnu'
+        'QT_INC_PATH': '/opt/qt6/include',
+        'QT_BIN_PATH': '/opt/qt6/libexec',
+        'QT_LIB_PATH': '/opt/qt6/lib'
     },
 }

--- a/wd.gypi
+++ b/wd.gypi
@@ -2,12 +2,12 @@
     'variables': {
         'QT5': '1',
         'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '0',
+        'WD_CONFIG_WEBKIT': '1',
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/opt/qt5/include',
-        'QT_BIN_PATH': '/opt/qt5/bin',
-        'QT_LIB_PATH': '/opt/qt5/lib'
+        'QT_INC_PATH': '/usr/include/x86_64-linux-gnu/qt5',
+        'QT_BIN_PATH': '/usr/bin',
+        'QT_LIB_PATH': '/usr/lib/x86_64-linux-gnu'
     },
 }

--- a/wd.gypi
+++ b/wd.gypi
@@ -1,12 +1,12 @@
 {
     'variables': {
-        'QT5': '1',
+        'QT6': '1',
         'WD_CONFIG_QWIDGET_BASE': '1',
         'WD_CONFIG_WEBKIT': '1',
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/usr/include/x86_64-linux-gnu/qt5',
+        'QT_INC_PATH': '/usr/include/x86_64-linux-gnu/qt6',
         'QT_BIN_PATH': '/usr/bin',
         'QT_LIB_PATH': '/usr/lib/x86_64-linux-gnu'
     },

--- a/wd_build_options.gypi
+++ b/wd_build_options.gypi
@@ -11,7 +11,7 @@
     '-Wall',
     '-W',
     '-Wno-unused-parameter',
-    '-std=gnu++11',
+    '-std=gnu++17',
   ],
 
   'defines': [

--- a/wd_ext_qt.gyp
+++ b/wd_ext_qt.gyp
@@ -60,7 +60,7 @@
 
       'conditions': [
       
-        ['<(QT5) == 0', {
+        ['<(QT5) == 0 and <(QT6) == 0', {
           'dependencies': [
             'src/third_party/mimetypes-qt4/mimetypes-qt4.gyp:mimetypes-qt4',
           ],
@@ -103,7 +103,7 @@
 
       'conditions': [
       
-        ['<(QT5) == 1', {
+        ['<(QT5) == 1 or <(QT6) == 1', {
 
           'sources': [
             'src/webdriver/extension_qt/qwindow_view_handle.cc',
@@ -138,7 +138,7 @@
 
       'conditions': [
       
-        ['<(QT5) == 1', {
+        ['<(QT5) == 1 or <(QT6) == 1', {
 
           'sources': [
             # TODO: Quick2 support

--- a/wd_test.gyp
+++ b/wd_test.gyp
@@ -18,7 +18,36 @@
     ],
 
     'conditions': [
-      [ '<(QT5) == 1', {
+      [ '<(QT6) == 1', {
+        'conditions': [
+          ['OS=="linux"', {
+            'libraries': [
+              '-L<(QT_LIB_PATH)',
+              '-lQt6Network',
+              '-lQt6Widgets',
+              '-lQt6Quick',
+              '-lQt6Qml',
+              '-lQt6Sql',
+              '-lQt6Gui',
+              '-lQt6Xml',
+              '-lQt6OpenGL',
+              '-lQt6PrintSupport',
+              '-lQt6Core',
+              '-lpthread',
+              '-lrt',
+              '-ldl',
+              '-licuuc',
+              '-licudata',
+              '-licui18n',
+              '-lQt6MultimediaWidgets',
+              '-lQt6Sensors',
+              '-lQt6Multimedia',
+              '-lQt6Positioning',
+              '-lQt6Core5Compat',
+            ],
+          } ],
+        ]
+      }, '<(QT5) == 1', {
         'conditions': [
           ['OS=="linux"', {
             'libraries': [
@@ -261,14 +290,14 @@
         '<(INTERMEDIATE_DIR)/moc_MenuTest.cc',
       ],
       'conditions': [
-        [ '<(QT5) == 1 and <(WD_CONFIG_PLAYER) == 1', {
+        [ '<(WD_CONFIG_PLAYER) == 1 and <(QT5) == 1 or <(QT6) == 1', {
           'sources': [
             'src/Test/VideoTest.h',
             'src/Test/VideoTest.cc',
             '<(INTERMEDIATE_DIR)/moc_VideoTest.cc',
           ],
         } ],
-        [ 'OS != "android" and <(QT5) == 0', {
+        [ 'OS != "android" and <(QT5) == 0 and <(QT6) == 0', {
           'sources': [
             'src/Test/WindowWithDeclarativeViewTest.cc',
             'src/Test/WindowWithDeclarativeViewTest.h',
@@ -314,7 +343,13 @@
           ],
         } ],
        
-        [ '<(QT5) == 1', {
+        [ '<(QT6) == 1', {
+          'conditions': [
+            ['OS=="linux"', {
+              'libraries': ['-lQt6WebKitWidgets', '-lQt6WebKit',],
+            } ],
+          ],
+        }, '<(QT5) == 1', {
           'conditions': [
             ['OS=="linux"', {
               'libraries': ['-lQt5WebKitWidgets', '-lQt5WebKit',],


### PR DESCRIPTION
## Description

PR to build qtwebdriver for qtwebengine rather than qtwebkit.
This is part of the work to remove qtwebkit from Boron to allow the Qt6 upgrade to take place.